### PR TITLE
Add support for systems with /boot outside the @-subvolume

### DIFF
--- a/snapper-rollback.conf
+++ b/snapper-rollback.conf
@@ -28,3 +28,10 @@ mountpoint = /btrfsroot
 # mount this device there before rolling back. This parameter is optional, but
 # if unset, you'll have to mount your btrfs root manually.
 #dev = /dev/sda42
+
+# If your /boot is located outside the `subvol_main` you have to back it up manually.
+# Please use the pacman-hook suggested in 
+# https://wiki.archlinux.org/title/System_backup#Snapshots_and_/boot_partition
+# In such a case set `external_boot` to True
+external_boot = False
+boot_backup_dir = /.bootbackup

--- a/snapper-rollback.py
+++ b/snapper-rollback.py
@@ -125,10 +125,23 @@ def rollback(subvol_main, subvol_main_newname, subvol_rollback_src, dev, dry_run
                 os.rename(subvol_main_newname, subvol_main)
 
 
+def rollback_boot_partiton(boot_backup_dir,dry_run):
+    full_path = boot_backup_dir+"/boot"
+    if dry_run: 
+        LOG.info("rm -rf /boot/*")
+        LOG.info("cp -a {}/* /boot/".format(full_path))
+    else:
+        os.system("rm -rf /boot/*")
+        os.system("cp -a {}/* /boot/".format(full_path))    
+
+
 def main():
     args = parse_args()
     config = read_config(args.config)
-
+    
+    if os.path.ismount("/boot") and config.get("root", "external_boot") == "False":
+        LOG.warning("/boot is outside the `subvol_main`, your system may not boot after rollback!")
+    
     mountpoint = pathlib.Path(config.get("root", "mountpoint"))
     subvol_main = mountpoint / config.get("root", "subvol_main")
     subvol_rollback_src = (
@@ -164,6 +177,12 @@ def main():
     except PermissionError as e:
         LOG.fatal("Permission denied: {}".format(e))
         exit(1)
+    try:
+        if config.get("root", "external_boot") == "True" and os.path.ismount("/boot"):
+            boot_backup_dir = str(subvol_rollback_src) + config.get("root", "boot_backup_dir")
+            rollback_boot_partiton(boot_backup_dir,dry_run=args.dry_run)
+    except Exception as e:
+        LOG.fatal("Error: {}".format(e))
 
 
 if __name__ == "__main__":

--- a/snapper-rollback.py
+++ b/snapper-rollback.py
@@ -50,7 +50,7 @@ def parse_args():
 
 
 def read_config(configfile):
-    config = configparser.ConfigParser()
+    config = configparser.ConfigParser({"external_boot":"False"})
     config.read(configfile)
     return config
 


### PR DESCRIPTION
Thanks for this nice tool.
If you have an encrypted system your `/boot ` is usually not part of the root-partition.
I`ve made a small patch which resets the boot-partition alongside with the @-subvolume.
It aussumes that you use the pacman-hook suggested in https://wiki.archlinux.org/title/System_backup#Snapshots_and_/boot_partition