### PR TITLE
Don't print successfull rollback as "FalseRollback"

### DIFF
--- a/snapper-rollback.py
+++ b/snapper-rollback.py
@@ -106,7 +106,7 @@ def rollback(subvol_main, subvol_main_newname, subvol_rollback_src, dev, dry_run
             btrfsutil.set_default_subvolume(subvol_main)
         LOG.info(
             "{}Rollback to {} complete. Reboot to finish".format(
-                dry_run and "[DRY-RUN MODE] ", subvol_rollback_src
+                "[DRY-RUN MODE] " if dry_run else "", subvol_rollback_src
             )
         )
     except FileNotFoundError as e:


### PR DESCRIPTION
Curently, when the procedure succeeds in a non-dry-run, it prints `FalseRollback`, which can be quite confusing.

This PR changes it to not print the "False" part.