### PR TITLE
feat: add post-rollback hook mechanism

### DIFF
--- a/snapper-rollback.conf
+++ b/snapper-rollback.conf
@@ -28,3 +28,26 @@ mountpoint = /btrfsroot
 # mount this device there before rolling back. This parameter is optional, but
 # if unset, you'll have to mount your btrfs root manually.
 #dev = /dev/sda42
+
+
+# OPTIONAL HOOK SECTION
+# Post-rollback hooks allow you to run commands after successful rollback
+# 
+# To use hooks:
+#   1. Remove the [hooks] section header comment below
+#   2. Add commands under 'post-rollback' option (one per line)
+#   3. Commands will execute in order after rollback completes
+#
+# Important notes:
+#   - Hooks run as the same user executing the rollback script (usually root)
+#   - Commands execute in the current system environment
+#   - Test commands thoroughly before putting them in production
+#   - Lines starting with '#' are treated as comments and ignored
+#
+# Example configuration:
+#[hooks]
+#post-rollback =
+#     # Remove the pacman lock file on the rolled back system. 
+#     rm -f /btrfsroot/@/var/lib/pacman/db.lck
+#     # Execute a custom shell script
+#     /custom/post-rollback-script.sh

--- a/snapper-rollback.conf
+++ b/snapper-rollback.conf
@@ -38,6 +38,10 @@ mountpoint = /btrfsroot
 #   2. Add commands under 'post-rollback' option (one per line)
 #   3. Commands will execute in order after rollback completes
 #
+# To disable hooks:
+#   - Simply keep the [hooks] section commented out
+#   - Or remove the [hooks] section entirely from your config
+#
 # Important notes:
 #   - Hooks run as the same user executing the rollback script (usually root)
 #   - Commands execute in the current system environment

--- a/snapper-rollback.py
+++ b/snapper-rollback.py
@@ -125,6 +125,29 @@ def rollback(subvol_main, subvol_main_newname, subvol_rollback_src, dev, dry_run
                 os.rename(subvol_main_newname, subvol_main)
 
 
+def run_hooks(config, dry_run=False):
+    """Execute post-rollback hook commands if defined in config"""
+    if not config.has_section("hooks"):
+        return
+    
+    if config.has_option("hooks", "post-rollback"):
+        commands = config.get("hooks", "post-rollback").splitlines()
+        LOG.info("Running post-rollback hooks")
+        
+        for cmd in commands:
+            cmd = cmd.strip()
+            if not cmd or cmd.startswith("#"):
+                continue
+                
+            if dry_run:
+                LOG.info(f"[DRY-RUN] Would run: {cmd}")
+            else:
+                LOG.info(f"Running: {cmd}")
+                ret = os.system(cmd)
+                if ret != 0:
+                    LOG.error(f"Hook command failed (exit={ret}): {cmd}")
+
+
 def main():
     args = parse_args()
     config = read_config(args.config)
@@ -161,6 +184,7 @@ def main():
             dev,
             dry_run=args.dry_run,
         )
+        run_hooks(config, dry_run=args.dry_run)
     except PermissionError as e:
         LOG.fatal("Permission denied: {}".format(e))
         exit(1)


### PR DESCRIPTION
feat: add post-rollback hook mechanism

- Implement run_hooks() function to execute post-rollback commands
- Support multiple commands from config's [hooks] section
- Handle dry-run mode for hook commands
- Execute hooks after successful rollback
- Maintain original error handling and rollback safety
- Ignore empty lines and comments in hook commands
- Log command execution with exit status reporting
- Follow the principle of minimal modification.