### PR TITLE
Add set_default_subvol parameter to allow disabling the set-default step

### DIFF
--- a/snapper-rollback.conf
+++ b/snapper-rollback.conf
@@ -28,3 +28,7 @@ mountpoint = /btrfsroot
 # mount this device there before rolling back. This parameter is optional, but
 # if unset, you'll have to mount your btrfs root manually.
 #dev = /dev/sda42
+# Whether to set the default subvolume.
+# If true, the subvolume specified in `subvol_main` will be set as default
+# for the btrfs root after a successful rollback.
+set_default_subvol = true

--- a/snapper-rollback.py
+++ b/snapper-rollback.py
@@ -99,7 +99,8 @@ def rollback(subvol_main, subvol_main_newname, subvol_rollback_src, dev, set_def
                     subvol_rollback_src, subvol_main
                 )
             )
-            LOG.info("btrfs subvolume set-default {}".format(subvol_main))
+            if set_default_subvol:
+                LOG.info("btrfs subvolume set-default {}".format(subvol_main))
         else:
             os.rename(subvol_main, subvol_main_newname)
             btrfsutil.create_snapshot(subvol_rollback_src, subvol_main)


### PR DESCRIPTION
Some users prefer keeping subvolid=5 as the default and mounting the root via subvol=@ instead (due to [GRUB issues](https://wiki.archlinux.org/title/Btrfs#Changing_the_default_sub-volume) or for organizational reasons). This adds a parameter in the config to toggle this step, as the rest of the rollback process is fully compatible with a default subvolid=5 setup.

Both the default value in the .conf and the default behavior of the script are left as `true` for consistency with the current version.